### PR TITLE
Fix research directors empty list in cms panel

### DIFF
--- a/site/blueprints/pages/project.yml
+++ b/site/blueprints/pages/project.yml
@@ -108,9 +108,9 @@ columns:
           research_directors:
             label: Research Directors
             type: pages
-            query: site.find('people').children.filterBy('role','researchDirector')
+            query: site.find('people').children
           members:
-            label: Members
+            label: Participants
             type: pages
             query: site.find('people').children
           contact:

--- a/site/snippets/pages/project.php
+++ b/site/snippets/pages/project.php
@@ -1,10 +1,10 @@
 <div class="container max-w-3xl py-4" x-data="{ participate: false }" x-init="setTimeout(() => participate = false, 5000)">
   <div class="mb-8">
-      <!-- Nav -->
+    <!-- Nav -->
     <div class="mb-8 flex flex-wrap">
-        <div class="flex-auto text-left">
-          <a href="<?= $page->parent()->url() ?>">&larr; All projects</a>
-        </div>
+      <div class="flex-auto text-left">
+        <a href="<?= $page->parent()->url() ?>">&larr; All projects</a>
+      </div>
     </div>
     <!-- End Nav -->
 
@@ -65,7 +65,7 @@
         <?php endif ?>
         <?php if ($page->members()->isNotEmpty()) : ?>
           <div>
-            <h5 class="mb-2">MEMBERS</h5>
+            <h5 class="mb-2">PARTICIPANTS</h5>
             <?php
             $members =  $page->members()->toPages();
             foreach ($members as $member) : ?>
@@ -108,28 +108,28 @@
     <?php endif ?>
 
     <hr />
-    
+
     <!-- Nav -->
     <div class="flex flex-wrap">
-        <div class="flex-auto text-left">
-          <?php
-          $collection = $page->siblings()->sortBy('title', 'asc');
-          if ($prev = $page->prevListed($collection)) : ?>
-            &larr; <a href="<?= $prev->url() ?>"><?= $prev->title() ?></a>
-          <?php endif ?>
-        </div>
+      <div class="flex-auto text-left">
+        <?php
+        $collection = $page->siblings()->sortBy('title', 'asc');
+        if ($prev = $page->prevListed($collection)) : ?>
+          &larr; <a href="<?= $prev->url() ?>"><?= $prev->title() ?></a>
+        <?php endif ?>
+      </div>
 
-        <div class="flex-auto text-center">
-          <a href="<?= $page->parent()->url() ?>">All projects</a>
-        </div>
+      <div class="flex-auto text-center">
+        <a href="<?= $page->parent()->url() ?>">All projects</a>
+      </div>
 
-        <div class="flex-auto text-right">
-          <?php
-          $collection = $page->siblings()->sortBy('title', 'asc');
-          if ($next = $page->nextListed($collection)) : ?>
-            <a href="<?= $next->url() ?>"><?= $next->title() ?></a> &rarr;
-          <?php endif ?>
-        </div>
+      <div class="flex-auto text-right">
+        <?php
+        $collection = $page->siblings()->sortBy('title', 'asc');
+        if ($next = $page->nextListed($collection)) : ?>
+          <a href="<?= $next->url() ?>"><?= $next->title() ?></a> &rarr;
+        <?php endif ?>
+      </div>
     </div>
     <!-- End Nav -->
 


### PR DESCRIPTION
This PR fixes bug in cms panel on the project page where the research directors select shows an empty list. It now shows all people for most flexibility.

It also changes the wording in panel and frontend, removing member in favour of participant.